### PR TITLE
Add leaderboard benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ Get around of a member
 ```go
 list, cursor _ := leaderboard.GetAround(ctx, "P4", 4, goleaderboard.OrderDesc)
 ```
+## Docker Compose
+To start Redis and run the example app use:
+```bash
+docker compose up
+```
+This starts a Redis container and executes `go run examples/main.go`.
+
 
 ## Contribution
 All your contributions to project and make it better, they are welcome. Feel free to start an [issue](https://github.com/duysmile/goleaderboard/issues).

--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ docker compose up
 ```
 This starts a Redis container and executes `go run examples/main.go`.
 
+## Running Benchmarks
+Ensure Redis is running (you can use the Compose file above) and then execute:
+```bash
+go test -bench=. -benchmem
+```
+The benchmarks in `benchmark_test.go` measure adding members and getting
+surrounding ranks.
+
 
 ## Contribution
 All your contributions to project and make it better, they are welcome. Feel free to start an [issue](https://github.com/duysmile/goleaderboard/issues).

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,60 @@
+package goleaderboard
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-redis/redis/v8"
+)
+
+func benchmarkSetup(b *testing.B) (*redis.Client, Leaderboard, context.Context) {
+	rdb := redis.NewClient(&redis.Options{
+		Addr:     "localhost:6379",
+		Password: "",
+		DB:       0,
+	})
+	if err := rdb.Ping(context.Background()).Err(); err != nil {
+		b.Fatalf("you must start redis server: %v", err)
+	}
+	lb := NewLeaderBoard(rdb, fmt.Sprintf("bench_%d", b.N), &Options{AllowSameRank: true})
+	ctx := context.Background()
+	return rdb, lb, ctx
+}
+
+func benchmarkTeardown(b *testing.B, rdb *redis.Client, lb Leaderboard, ctx context.Context) {
+	lb.Clean(ctx)
+	rdb.Close()
+}
+
+func BenchmarkAddMember(b *testing.B) {
+	rdb, lb, ctx := benchmarkSetup(b)
+	defer benchmarkTeardown(b, rdb, lb, ctx)
+
+	// Prepopulate leaderboard with a large number of members
+	const preMembers = 10000
+	for i := 0; i < preMembers; i++ {
+		lb.AddMember(ctx, fmt.Sprintf("pre_%d", i), preMembers-i)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		lb.AddMember(ctx, fmt.Sprintf("bm_%d", i), i)
+	}
+}
+
+func BenchmarkGetAround(b *testing.B) {
+	rdb, lb, ctx := benchmarkSetup(b)
+	defer benchmarkTeardown(b, rdb, lb, ctx)
+
+	const members = 10000
+	for i := 0; i < members; i++ {
+		lb.AddMember(ctx, fmt.Sprintf("m_%d", i), members-i)
+	}
+	target := fmt.Sprintf("m_%d", members/2)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		lb.GetAround(ctx, target, 10, OrderDesc)
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.8"
+
+services:
+  redis:
+    image: redis:6-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis-data:/data
+
+  example:
+    image: golang:1.17-alpine
+    working_dir: /app
+    command: go run examples/main.go
+    volumes:
+      - .:/app
+    depends_on:
+      - redis
+
+volumes:
+  redis-data:


### PR DESCRIPTION
## Summary
- add benchmark tests for leaderboard operations

## Testing
- `go test ./...` *(fails: unable to fetch go modules)*

------
https://chatgpt.com/codex/tasks/task_e_685276949c2c83288759fc3ae88029de